### PR TITLE
change hetio to hetnetpy

### DIFF
--- a/software/index.html
+++ b/software/index.html
@@ -12,9 +12,9 @@ category: software
       <div class="col_text">
         <p>
           <i>Hetnetpy</i> (<a href="https://github.com/hetio/hetnetpy/issues/40"
-            >previously</a
+            >previously called</a
           >
-          just <i>hetio</i>) is a Python 3 package for creating, querying, and
+          <i>hetio</i>) is a Python 3 package for creating, querying, and
           operating on hetnets. This software provides convenient data
           structures for hetnets, as well as algorithms for
           <a href="/hnep">edge prediction</a>. It is specifically tailored and

--- a/software/index.html
+++ b/software/index.html
@@ -5,23 +5,23 @@ icon: fas fa-code
 category: software
 ---
 
-<section id="hetio">
+<section id="hetnetpy">
   <div class="section">
-    <h3><code>hetio</code></h3>
+    <h3><code>hetnetpy</code></h3>
     <div class="row">
       <div class="col_text">
         <p>
-          <i>Hetio</i> is a Python 3 package for creating, querying, and
+          <i>Hetnetpy</i> is a Python 3 package for creating, querying, and
           operating on hetnets. This software provides convenient data
           structures for hetnets, as well as algorithms for
           <a href="/hnep">edge prediction</a>. It is specifically tailored and
           streamlined for hetnets compared to other more generic network
           software.
         </p>
-        <a href="https://github.com/hetio/hetio" class="button"
+        <a href="https://github.com/hetio/hetnetpy" class="button"
           >View on GitHub<i class="fab fa-github" data-right></i
         ></a>
-        <a href="https://pypi.org/project/hetio/" class="button"
+        <a href="https://pypi.org/project/hetnetpy" class="button"
           >View on PyPI<i class="fab fa-python" data-right></i
         ></a>
       </div>
@@ -41,8 +41,8 @@ category: software
           <i>Hetmatpy</i> is a Python 3 package storing and operating on hetnets
           in matrix form. Representing the network in this way enables counting
           paths using matrix multiplication, which provides dramatically better
-          performance compared to the equivalent <i>hetio</i> or Neo4j
-          implementations. <i>Hetmatpy</i> depends on <i>hetio</i> for
+          performance compared to the equivalent <i>hetnetpy</i> or Neo4j
+          implementations. <i>Hetmatpy</i> depends on <i>hetnetpy</i> for
           representing the metagraph (network schema), but is better-suited for
           certain large-scale computations.
         </p>
@@ -69,7 +69,7 @@ category: software
           metrics and computing the prior probability that an edge exists based
           on its source and target degree. The computation-intensive portions of
           the package are implemented in C/C++ to provide rapid permutation and
-          significantly better performance than the legacy <i>hetio</i> pure
+          significantly better performance than the legacy <i>hetnetpy</i> pure
           Python implementation.
         </p>
         <a href="https://github.com/greenelab/xswap" class="button"

--- a/software/index.html
+++ b/software/index.html
@@ -12,9 +12,9 @@ category: software
       <div class="col_text">
         <p>
           <i>Hetnetpy</i> (<a href="https://github.com/hetio/hetnetpy/issues/40"
-            >previously called</a
+            >previously</a
           >
-          <i>hetio</i>) is a Python 3 package for creating, querying, and
+          just <i>hetio</i>) is a Python 3 package for creating, querying, and
           operating on hetnets. This software provides convenient data
           structures for hetnets, as well as algorithms for
           <a href="/hnep">edge prediction</a>. It is specifically tailored and

--- a/software/index.html
+++ b/software/index.html
@@ -11,7 +11,10 @@ category: software
     <div class="row">
       <div class="col_text">
         <p>
-          <i>Hetnetpy</i> is a Python 3 package for creating, querying, and
+          <i>Hetnetpy</i> (<a href="https://github.com/hetio/hetnetpy/issues/40"
+            >previously called</a
+          >
+          <i>hetio</i>) is a Python 3 package for creating, querying, and
           operating on hetnets. This software provides convenient data
           structures for hetnets, as well as algorithms for
           <a href="/hnep">edge prediction</a>. It is specifically tailored and


### PR DESCRIPTION
This PR changes the name of the `hetio` software to `hetnetpy` per https://github.com/hetio/hetnetpy/issues/40

I don't believe there was anywhere else that we mentioned the `hetio` software other than the software page. Please double check me on that @dhimmel .

Ignore the name of the branch, that was a mistake.